### PR TITLE
gl_buffer_cache: Add missing include

### DIFF
--- a/src/video_core/renderer_opengl/gl_buffer_cache.cpp
+++ b/src/video_core/renderer_opengl/gl_buffer_cache.cpp
@@ -8,6 +8,7 @@
 
 #include "common/assert.h"
 #include "common/microprofile.h"
+#include "video_core/rasterizer_interface.h"
 #include "video_core/renderer_opengl/gl_buffer_cache.h"
 #include "video_core/renderer_opengl/gl_rasterizer.h"
 #include "video_core/renderer_opengl/gl_resource_manager.h"


### PR DESCRIPTION
RasterizerInterface was considered an incomplete object by clang.